### PR TITLE
Split site into multiple pages and fix layout

### DIFF
--- a/actualites.html
+++ b/actualites.html
@@ -3,13 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Anto Moto - Réparation et entretien de motos et scooters. Réservez vos interventions en ligne.">
-    <title>Anto Moto - Atelier mécanique moto et scooter</title>
+    <meta name="description" content="Anto Moto - Actualités du monde de la moto.">
+    <title>Anto Moto - Actualités</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-    <!-- HEADER -->
     <header>
         <div class="logo">Anto Moto</div>
         <nav>
@@ -20,21 +18,22 @@
             <a href="contact.html">Contact</a>
         </nav>
     </header>
-
-    <!-- SECTION ACCUEIL -->
-    <section id="accueil" class="hero hidden">
-        <div class="hero-text">
-            <h1>Bienvenue chez Anto Moto</h1>
-            <p>Votre atelier mécanique spécialisé moto et scooter. Réservez vos réparations en ligne.</p>
-            <a href="reservation.html" class="btn">Réserver maintenant</a>
+    <section id="actualites" class="hidden">
+        <h2>Actualités Moto</h2>
+        <div class="news-grid">
+            <article>
+                <h3>Course 50cc à venir</h3>
+                <p>Découvrez les prochaines compétitions régionales.</p>
+            </article>
+            <article>
+                <h3>Conseils d’entretien</h3>
+                <p>Comment prolonger la durée de vie de votre moto.</p>
+            </article>
         </div>
     </section>
-
-    <!-- FOOTER -->
     <footer>
         <p>© 2025 Anto Moto - Tous droits réservés</p>
     </footer>
-
     <script src="script.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -3,13 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Anto Moto - Réparation et entretien de motos et scooters. Réservez vos interventions en ligne.">
-    <title>Anto Moto - Atelier mécanique moto et scooter</title>
+    <meta name="description" content="Anto Moto - Contactez-nous.">
+    <title>Anto Moto - Contact</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-    <!-- HEADER -->
     <header>
         <div class="logo">Anto Moto</div>
         <nav>
@@ -20,21 +18,14 @@
             <a href="contact.html">Contact</a>
         </nav>
     </header>
-
-    <!-- SECTION ACCUEIL -->
-    <section id="accueil" class="hero hidden">
-        <div class="hero-text">
-            <h1>Bienvenue chez Anto Moto</h1>
-            <p>Votre atelier mécanique spécialisé moto et scooter. Réservez vos réparations en ligne.</p>
-            <a href="reservation.html" class="btn">Réserver maintenant</a>
-        </div>
+    <section id="contact" class="hidden">
+        <h2>Contact</h2>
+        <p>Email : <a href="mailto:contact@antomoto.net">contact@antomoto.net</a></p>
+        <p>Suivez-nous sur nos réseaux sociaux</p>
     </section>
-
-    <!-- FOOTER -->
     <footer>
         <p>© 2025 Anto Moto - Tous droits réservés</p>
     </footer>
-
     <script src="script.js"></script>
 </body>
 </html>

--- a/reservation.html
+++ b/reservation.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Anto Moto - Réserver une intervention.">
+    <title>Anto Moto - Réservation</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <div class="logo">Anto Moto</div>
+        <nav>
+            <a href="index.html">Accueil</a>
+            <a href="services.html">Services</a>
+            <a href="reservation.html">Réservation</a>
+            <a href="actualites.html">Actualités</a>
+            <a href="contact.html">Contact</a>
+        </nav>
+    </header>
+    <section id="reservation" class="hidden">
+        <h2>Réserver une intervention</h2>
+        <form action="https://formspree.io/f/mnqebjdd" method="POST">
+            <input type="text" name="name" placeholder="Votre nom" required>
+            <input type="email" name="_replyto" placeholder="Votre email" required>
+            <input type="tel" name="phone" placeholder="Votre téléphone" required>
+            <select name="type" required>
+                <option value="">Type de véhicule</option>
+                <option value="Scooter">Scooter</option>
+                <option value="Moto routière">Moto routière</option>
+                <option value="Moto cross">Moto cross</option>
+                <option value="Scooter piste">Scooter piste</option>
+                <option value="Moto piste ext">Moto piste ext</option>
+            </select>
+            <textarea name="message" placeholder="Description de l'intervention souhaitée" required></textarea>
+            <button type="submit">Envoyer la demande</button>
+        </form>
+    </section>
+    <footer>
+        <p>© 2025 Anto Moto - Tous droits réservés</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -8,26 +8,29 @@ const observer = new IntersectionObserver((entries) => {
 
 document.querySelectorAll('.hidden').forEach((el) => observer.observe(el));
 
-window.addEventListener('scroll', function () {
-    const hero = document.querySelector('.hero');
-    let offset = window.pageYOffset;
-    hero.style.backgroundPositionY = offset * 0.5 + "px";
-});
+const hero = document.querySelector('.hero');
+if (hero) {
+    window.addEventListener('scroll', function () {
+        let offset = window.pageYOffset;
+        hero.style.backgroundPositionY = offset * 0.5 + "px";
+    });
+}
 
 document.addEventListener('DOMContentLoaded', function () {
     const form = document.querySelector('#reservation form');
+    if (!form) return;
     form.setAttribute('action', 'https://formspree.io/f/mnqebjdd');
-    
+
     form.addEventListener('submit', async function (event) {
         event.preventDefault();
         const data = new FormData(form);
-        
+
         const response = await fetch(form.action, {
             method: 'POST',
             body: data,
             headers: { 'Accept': 'application/json' }
         });
-        
+
         if (response.ok) {
             alert('Votre demande a été envoyée avec succès. Nous vous contacterons rapidement.');
             form.reset();

--- a/services.html
+++ b/services.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Anto Moto - Nos services de réparation et entretien.">
+    <title>Anto Moto - Services</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <div class="logo">Anto Moto</div>
+        <nav>
+            <a href="index.html">Accueil</a>
+            <a href="services.html">Services</a>
+            <a href="reservation.html">Réservation</a>
+            <a href="actualites.html">Actualités</a>
+            <a href="contact.html">Contact</a>
+        </nav>
+    </header>
+    <section id="services" class="hidden">
+        <h2>Nos Services</h2>
+        <div class="services-grid">
+            <div class="service">
+                <h3>Scooters &amp; Motos routières</h3>
+                <p>Révisions complètes uniquement.</p>
+            </div>
+            <div class="service">
+                <h3>Motos cross &amp; scooters piste</h3>
+                <p>Tout sauf préparation amortisseur.</p>
+            </div>
+            <div class="service">
+                <h3>Conseils &amp; entretien</h3>
+                <p>Conseils personnalisés et suivi de votre machine.</p>
+            </div>
+        </div>
+    </section>
+    <footer>
+        <p>© 2025 Anto Moto - Tous droits réservés</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -10,6 +10,7 @@ body {
     color: #fff;
     line-height: 1.6;
     overflow-x: hidden;
+    padding-top: 80px;
 }
 
 header {
@@ -57,7 +58,7 @@ h2 {
 }
 
 .hero {
-    height: 100vh;
+    min-height: calc(100vh - 80px);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -66,6 +67,7 @@ h2 {
     background-size: cover;
     background-position: center;
     background-attachment: fixed;
+    padding: 0 10%;
 }
 
 .hero-text h1 {


### PR DESCRIPTION
## Summary
- Split single-page site into dedicated pages for services, reservations, news and contact
- Fix header overlap by adding top padding and adjusted hero height
- Add "Moto piste ext" vehicle option and make scripts resilient per page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b2da393dc8323a5a78eee9aa8033a